### PR TITLE
Fixes a typo in the json output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+**/launchSettings.json

--- a/TMFileParser/TMFileParser/Models/output/TM7Diagram.cs
+++ b/TMFileParser/TMFileParser/Models/output/TM7Diagram.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TMFileParser.Models.output
 {
@@ -11,7 +7,7 @@ namespace TMFileParser.Models.output
     public class TM7Diagram
     {
         public string diagram { get; set; }
-        public List<TM7Boundary> bondaries { get; set; }
+        public List<TM7Boundary> boundaries { get; set; }
         public List<TM7Connector> connectors { get; set; }
         public List<TM7Asset> assets { get; set; }
     }

--- a/TMFileParser/TMFileParser/TM7FileReader.cs
+++ b/TMFileParser/TMFileParser/TM7FileReader.cs
@@ -135,7 +135,7 @@ namespace TMFileParser
                         assets.Add(asset);
                     }
                 }
-                diagram.bondaries = boundaries;
+                diagram.boundaries = boundaries;
                 diagram.connectors = connectors;
                 diagram.assets = assets;
                 diagrams.Add(diagram);
@@ -161,7 +161,7 @@ namespace TMFileParser
                 case "boundaries":
                     return this._tmAllData.diagrams.Select(x => new { 
                         x.diagram,
-                        x.bondaries
+                        x.boundaries
                     });             
                 case "connectors":
                     return this._tmAllData.diagrams.Select(x => new {

--- a/TMFileParser/TMFileParserTest/TM7FileReaderTest.cs
+++ b/TMFileParser/TMFileParserTest/TM7FileReaderTest.cs
@@ -36,7 +36,7 @@ namespace TMFileParserTest
             reader = new TM7FileReader(new FileInfo(tm7EmptyFilePath));
             var tmData = (TM7All)reader.GetData("all");
             Assert.AreEqual(tmData.diagrams.FirstOrDefault().assets.Count(), 0);
-            Assert.AreEqual(tmData.diagrams.FirstOrDefault().bondaries.Count(), 0);
+            Assert.AreEqual(tmData.diagrams.FirstOrDefault().boundaries.Count(), 0);
             Assert.AreEqual(tmData.diagrams.FirstOrDefault().connectors.Count(), 0);
             Assert.AreEqual(tmData.threats.Count(), 0);
         }


### PR DESCRIPTION
The model misspells `boundaries` as `bondaries` - this makes it all the way into the json output:

![image](https://user-images.githubusercontent.com/88204686/207473453-1f8ec955-5b2a-4e22-a2e3-3c136e28db66.png)
